### PR TITLE
Fix bug in merge_output_configs

### DIFF
--- a/Bugs.md
+++ b/Bugs.md
@@ -1170,3 +1170,12 @@ leading to a termination of cagebreak.
   * Fixed: 2.1.0
 
 Prior to release 2.1.0 `meson install` did not work perfectly.
+
+## Issue 60
+
+  * github issue number: N/A
+  * Fixed: 2.1.2
+
+In the `merge_output_configs` function, when copying the properties of
+one config to another, the `angles` element of an input structure was
+being copied to the `status` element of the resultant structure.

--- a/output.c
+++ b/output.c
@@ -399,7 +399,7 @@ merge_output_configs(struct cg_output_config *cfg1,
 		out_cfg->scale = cfg1->scale;
 	}
 	if(cfg1->angle == out_cfg->angle) {
-		out_cfg->status = cfg2->angle;
+		out_cfg->angle = cfg2->angle;
 	} else {
 		out_cfg->angle = cfg1->angle;
 	}


### PR DESCRIPTION
I've put 'Fixed: 2.1.2' in Bugs.md, assuming that would be the next version.  If that's not how that file is meant to work, I can change it (or you can maybe? I don't know how github works).