### PR TITLE
implement move{left,up,right,down} following exchange* variants

### DIFF
--- a/keybinding.c
+++ b/keybinding.c
@@ -274,6 +274,49 @@ swap_tile_bottom(struct cg_tile *tile) {
 }
 
 void
+move_tile(struct cg_tile *tile,
+		  struct cg_tile *(*find_tile)(const struct cg_tile *)) {
+	struct cg_tile *move_tile = find_tile(tile);
+	if(move_tile == NULL || move_tile == tile) {
+		return;
+	}
+	workspace_tile_update_view(move_tile, tile->view);
+	workspace_tile_update_view(tile, NULL);
+	struct cg_server *server = move_tile->workspace->server;
+	workspace_focus_tile(
+		server->curr_output->workspaces[server->curr_output->curr_workspace],
+		move_tile);
+	seat_set_focus(server->seat, move_tile->view);
+	ipc_send_event(
+		move_tile->workspace->output->server,
+		"{\"event_name\":\"move_tile\",\"tile_id\":%d,\"move_"
+		"tile_id\":%d,\"workspace\":%d,\"output\":\"%s\",\"output_id\":%d}",
+		move_tile->id, move_tile->workspace->num + 1,
+		move_tile->workspace->output->wlr_output->name,
+		output_get_num(move_tile->workspace->output));
+}
+
+void
+move_tile_left(struct cg_tile *tile) {
+	move_tile(tile, find_left_tile);
+}
+
+void
+move_tile_right(struct cg_tile *tile) {
+	move_tile(tile, find_right_tile);
+}
+
+void
+move_tile_top(struct cg_tile *tile) {
+	move_tile(tile, find_top_tile);
+}
+
+void
+move_tile_bottom(struct cg_tile *tile) {
+	move_tile(tile, find_bottom_tile);
+}
+
+void
 focus_tile(struct cg_tile *tile,
            struct cg_tile *(*find_tile)(const struct cg_tile *tile)) {
 	struct cg_tile *new_tile = find_tile(tile);
@@ -1755,6 +1798,30 @@ run_action(enum keybinding_action action, struct cg_server *server,
 	}
 	case KEYBINDING_SWAP_BOTTOM: {
 		swap_tile_bottom(
+		    server->curr_output->workspaces[server->curr_output->curr_workspace]
+		        ->focused_tile);
+		break;
+	}
+	case KEYBINDING_MOVE_LEFT: {
+		move_tile_left(
+		    server->curr_output->workspaces[server->curr_output->curr_workspace]
+		        ->focused_tile);
+		break;
+	}
+	case KEYBINDING_MOVE_RIGHT: {
+		move_tile_right(
+		    server->curr_output->workspaces[server->curr_output->curr_workspace]
+		        ->focused_tile);
+		break;
+	}
+	case KEYBINDING_MOVE_TOP: {
+		move_tile_top(
+		    server->curr_output->workspaces[server->curr_output->curr_workspace]
+		        ->focused_tile);
+		break;
+	}
+	case KEYBINDING_MOVE_BOTTOM: {
+		move_tile_bottom(
 		    server->curr_output->workspaces[server->curr_output->curr_workspace]
 		        ->focused_tile);
 		break;

--- a/keybinding.h
+++ b/keybinding.h
@@ -71,6 +71,11 @@ struct cg_server;
 	KEYBINDING(KEYBINDING_SWAP_TOP, exchangeup)                                \
 	KEYBINDING(KEYBINDING_SWAP_BOTTOM, exchangedown)                           \
                                                                                \
+	KEYBINDING(KEYBINDING_MOVE_LEFT, moveleft)                                 \
+	KEYBINDING(KEYBINDING_MOVE_RIGHT, moveright)                               \
+	KEYBINDING(KEYBINDING_MOVE_TOP, moveup)                                    \
+	KEYBINDING(KEYBINDING_MOVE_BOTTOM, movedown)                               \
+																			   \
 	KEYBINDING(KEYBINDING_FOCUS_LEFT, focusleft)                               \
 	KEYBINDING(KEYBINDING_FOCUS_RIGHT, focusright)                             \
 	KEYBINDING(KEYBINDING_FOCUS_TOP, focusup)                                  \

--- a/parse.c
+++ b/parse.c
@@ -924,6 +924,14 @@ parse_command(struct cg_server *server, struct keybinding *keybinding,
 		keybinding->action = KEYBINDING_SWAP_TOP;
 	} else if(strcmp(action, "exchangedown") == 0) {
 		keybinding->action = KEYBINDING_SWAP_BOTTOM;
+	} else if(strcmp(action, "moveleft") == 0) {
+		keybinding->action = KEYBINDING_MOVE_LEFT;
+	} else if(strcmp(action, "moveright") == 0) {
+		keybinding->action = KEYBINDING_MOVE_RIGHT;
+	} else if(strcmp(action, "moveup") == 0) {
+		keybinding->action = KEYBINDING_MOVE_TOP;
+	} else if(strcmp(action, "movedown") == 0) {
+		keybinding->action = KEYBINDING_MOVE_BOTTOM;
 	} else if(strcmp(action, "focusleft") == 0) {
 		keybinding->action = KEYBINDING_FOCUS_LEFT;
 	} else if(strcmp(action, "focusright") == 0) {


### PR DESCRIPTION
Hi all,

Thanks for this great project. I just picked this up and found that i was missing the `move*` bindings from ratpoison. At a glance i don't think i saw any obvious contribution/formatting guidelines, but please lmk if i missed something.

This PR implements `move{left,up,down,right}` commands for which i basically copied the code from `exchange*`.